### PR TITLE
Use 'Cloud Services' instead of 'Labs'

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -38,4 +38,4 @@ composer test
 - Consider [wikimedia/toolforge-bundle](https://packagist.org/packages/wikimedia/toolforge-bundle) for better structure and long-term maintenance
 
 ## Contributors 
- * Samuel Guebo ([@samuelguebo](https://twitter/com/samuelguebo))
+ * Samuel Guebo ([@samuelguebo](https://twitter.com/samuelguebo))

--- a/src/Views/footer.php
+++ b/src/Views/footer.php
@@ -8,7 +8,7 @@
 	<div class="container boxed">
 			<div class="row">
 				<div class="">
-				<a href="https://wikitech.wikimedia.org/wiki/Wikitech:Labs_Terms_of_use">Terms of Use</a> | Written by <a href="https://meta.wikimedia.org/wiki/User:African Hope">Samuel Guebo</a> | <a href="https://github.com/samuelguebo/thenoun-uploader">Source code </a>
+				<a href="https://wikitech.wikimedia.org/wiki/Wikitech:Cloud_Services_Terms_of_use">Terms of Use</a> | Written by <a href="https://meta.wikimedia.org/wiki/User:African Hope">Samuel Guebo</a> | <a href="https://github.com/samuelguebo/thenoun-uploader">Source code </a>
 				</div>
 			</div>
 		</div>

--- a/src/Views/logged-out.php
+++ b/src/Views/logged-out.php
@@ -30,7 +30,7 @@
 						<a class="btn btn-primary btn-lg btn-login md-opjjpmhoiojifppkkcdabiobhakljdgm_doc" href="/login"
 							role="button"><i class="fa fa-sign-in"></i> Login with Wikimedia</a>
 					</p>
-					<p class="tou-description">By logging in, you agree to the <a href="https://wikitech.wikimedia.org/wiki/Wikitech:Labs_Terms_of_use">Wikimedia Labs Terms of Use</a></p>
+					<p class="tou-description">By logging in, you agree to the <a href="https://wikitech.wikimedia.org/wiki/Wikitech:Cloud_Services_Terms_of_use">Wikimedia Cloud Services Terms of Use</a></p>
 				</div>
 		<br>
 		<br>


### PR DESCRIPTION
The current name for 'Labs' is 'Cloud Services' also corrected a typo in a Twitter URL